### PR TITLE
Add hexagonal version toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Both of these examples are beautiful illustrations of emergent behavior from see
 
 ## Running the simulation
 
-Use `python3 collatz_ant.py <start_value> -s <steps>` to run the simulation. The script prints each step with the current position, value and cell color.
+Use `python3 collatz_ant.py <start_value> -s <steps> [--version MODE]` to run the simulation. The script prints each step with the current position, value and cell color. `MODE` can be `regular` (default) or `hexagonal`.
 
-To watch the ant move on a scrollable grid, run `python3 visuals.py <start_value> -s <steps>`.
+To watch the ant move on a scrollable grid, run `python3 visuals.py <start_value> -s <steps> [--version MODE]`.
 Each cell displays its computed value and the text automatically shrinks so it always fits inside the square. Use the mouse wheel to zoom in or out.
 Hold the `Ctrl` key while scrolling to move vertically and hold `Shift` for horizontal movement. Drag with the left mouse button to pan around the grid. Press `t` to cycle through animation speeds. The viewer listens for mouse-wheel events globally so zoom works across platforms and now supports unlimited zoom in either direction.
 

--- a/collatz_ant.py
+++ b/collatz_ant.py
@@ -10,27 +10,39 @@ from typing import Dict, Tuple, Iterable
 Position = Tuple[int, int]
 
 
-def turn_left(orientation: int) -> int:
-    """Rotate 90 degrees counter clockwise."""
-    return (orientation - 1) % 4
+def turn_left(orientation: int, mod: int) -> int:
+    """Rotate ``orientation`` counter-clockwise."""
+    return (orientation - 1) % mod
 
 
-def turn_right(orientation: int) -> int:
-    """Rotate 90 degrees clockwise."""
-    return (orientation + 1) % 4
+def turn_right(orientation: int, mod: int) -> int:
+    """Rotate ``orientation`` clockwise."""
+    return (orientation + 1) % mod
 
 
-def move_forward(position: Position, orientation: int) -> Position:
+def move_forward(position: Position, orientation: int, version: str) -> Position:
     """Move one unit forward from ``position`` in ``orientation``."""
     x, y = position
-    if orientation == 0:  # up
-        return x, y + 1
-    if orientation == 1:  # right
-        return x + 1, y
-    if orientation == 2:  # down
-        return x, y - 1
-    if orientation == 3:  # left
-        return x - 1, y
+    if version == "regular":
+        if orientation == 0:  # up
+            return x, y + 1
+        if orientation == 1:  # right
+            return x + 1, y
+        if orientation == 2:  # down
+            return x, y - 1
+        if orientation == 3:  # left
+            return x - 1, y
+    elif version == "hexagonal":
+        deltas = [
+            (0, 1),  # north
+            (1, 0),  # north-east
+            (1, -1),  # south-east
+            (0, -1),  # south
+            (-1, 0),  # south-west
+            (-1, 1),  # north-west
+        ]
+        dx, dy = deltas[orientation]
+        return x + dx, y + dy
     raise ValueError(f"Invalid orientation {orientation}")
 
 
@@ -39,12 +51,20 @@ class CollatzAnt:
     """Stateful Collatz Ant implementation."""
 
     start_value: int
+    version: str = "regular"
     grid: Dict[Position, int] = field(default_factory=dict)
     position: Position = (0, 0)
-    orientation: int = 0  # 0=up,1=right,2=down,3=left
+    orientation: int = 0  # orientation index
+    orientation_mod: int = field(init=False)
 
     def __post_init__(self) -> None:
         self.grid[self.position] = self.start_value
+        if self.version == "regular":
+            self.orientation_mod = 4
+        elif self.version == "hexagonal":
+            self.orientation_mod = 6
+        else:
+            raise ValueError(f"Unknown version {self.version}")
 
     def step(self) -> Tuple[Position, int]:
         """Advance the ant by a single step.
@@ -54,13 +74,13 @@ class CollatzAnt:
 
         current_value = self.grid[self.position]
         if current_value % 2 == 0:
-            self.orientation = turn_right(self.orientation)
+            self.orientation = turn_right(self.orientation, self.orientation_mod)
             new_value = current_value // 2
         else:
-            self.orientation = turn_left(self.orientation)
+            self.orientation = turn_left(self.orientation, self.orientation_mod)
             new_value = 3 * current_value + 1
 
-        self.position = move_forward(self.position, self.orientation)
+        self.position = move_forward(self.position, self.orientation, self.version)
         self.grid[self.position] = new_value
         return self.position, new_value
 
@@ -72,10 +92,10 @@ class CollatzAnt:
             yield self.step()
 
 
-def simulate(start_value: int, steps: int) -> Iterable[Tuple[Position, int]]:
+def simulate(start_value: int, steps: int, version: str = "regular") -> Iterable[Tuple[Position, int]]:
     """Utility function returning ``steps`` steps of the simulation."""
 
-    ant = CollatzAnt(start_value)
+    ant = CollatzAnt(start_value, version=version)
     yield from ant.history(steps)
 
 
@@ -83,9 +103,15 @@ def main():
     parser = argparse.ArgumentParser(description="Collatz Ant simulation")
     parser.add_argument("start", type=int, help="Starting value (N0)")
     parser.add_argument("-s", "--steps", type=int, default=20, help="Number of steps to simulate")
+    parser.add_argument(
+        "--version",
+        choices=["regular", "hexagonal"],
+        default="regular",
+        help="Simulation mode to use",
+    )
     args = parser.parse_args()
 
-    for step, (pos, val) in enumerate(simulate(args.start, args.steps)):
+    for step, (pos, val) in enumerate(simulate(args.start, args.steps, args.version)):
         x, y = pos
         color = "black" if val % 2 else "white"
         print(

--- a/visuals.py
+++ b/visuals.py
@@ -11,8 +11,8 @@ INITIAL_EXTENT = 500  # initial half-size of the scroll region
 
 
 class AntVisualizer:
-    def __init__(self, start_value: int, steps: int |None, delay: int = DELAY) -> None:
-        self.ant = CollatzAnt(start_value)
+    def __init__(self, start_value: int, steps: int |None, delay: int = DELAY, version: str = "regular") -> None:
+        self.ant = CollatzAnt(start_value, version=version)
         self.steps = steps
         self.delay = delay
         self.delay_options = [50, 100, 200, 400, 800]
@@ -178,13 +178,19 @@ def main() -> None:
     parser.add_argument("-s", "--steps", type=int, help="Number of steps to simulate")
     parser.add_argument("-d", "--delay", type=int, default=DELAY, help="Delay between steps in ms")
     parser.add_argument("--speed", type=float, help="Animation speed in steps per second")
+    parser.add_argument(
+        "--version",
+        choices=["regular", "hexagonal"],
+        default="regular",
+        help="Simulation mode to use",
+    )
     args = parser.parse_args()
 
     delay = args.delay
     if args.speed is not None:
         delay = int(1000 / args.speed) if args.speed > 0 else 0
 
-    AntVisualizer(args.start, args.steps, delay).run()
+    AntVisualizer(args.start, args.steps, delay, args.version).run()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `--version` flag with `regular` and `hexagonal` modes
- support hexagonal movement and orientation logic
- allow viewer to choose simulation version
- document new flag in README

## Testing
- `python3 -m py_compile collatz_ant.py visuals.py`
- `python3 collatz_ant.py 5 -s 2 --version hexagonal`
- `python3 visuals.py 5 -s 2 --version hexagonal --speed 10` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_6850f913862883298c1f997dffd4fd89