### PR TITLE
Add grid-based loop detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ You can also set the animation speed from the command line with `--speed` to spe
 python3 visuals.py 124 -s 600 --speed 50
 ```
 
+At the end of a run in regular mode, the program analyzes the grid to detect
+closed loops in the ant's path. The total number of loops is printed to the
+console and shown in the bottom-right corner of the visualizer.
+

--- a/collatz_ant.py
+++ b/collatz_ant.py
@@ -4,7 +4,8 @@
 
 import argparse
 from dataclasses import dataclass, field
-from typing import Dict, Tuple, Iterable
+from typing import Dict, Iterable, Tuple
+from collections import deque
 
 
 Position = Tuple[int, int]
@@ -46,6 +47,50 @@ def move_forward(position: Position, orientation: int, version: str) -> Position
     raise ValueError(f"Invalid orientation {orientation}")
 
 
+def count_loops(grid: Dict[Position, int]) -> int:
+    """Return the number of enclosed empty regions in ``grid``."""
+    if not grid:
+        return 0
+
+    xs = [x for x, _ in grid.keys()]
+    ys = [y for _, y in grid.keys()]
+    min_x, max_x = min(xs) - 1, max(xs) + 1
+    min_y, max_y = min(ys) - 1, max(ys) + 1
+    width = max_x - min_x + 1
+    height = max_y - min_y + 1
+
+    # build binary map of visited cells
+    visited_map = [[0] * width for _ in range(height)]
+    for x, y in grid.keys():
+        row = max_y - y
+        col = x - min_x
+        visited_map[row][col] = 1
+
+    dirs = [(1, 0), (-1, 0), (0, 1), (0, -1)]
+    seen = [[False] * width for _ in range(height)]
+    loops = 0
+
+    for r in range(height):
+        for c in range(width):
+            if visited_map[r][c] == 0 and not seen[r][c]:
+                queue = deque([(r, c)])
+                seen[r][c] = True
+                touches_border = False
+                while queue:
+                    cr, cc = queue.popleft()
+                    if cr == 0 or cr == height - 1 or cc == 0 or cc == width - 1:
+                        touches_border = True
+                    for dr, dc in dirs:
+                        nr, nc = cr + dr, cc + dc
+                        if 0 <= nr < height and 0 <= nc < width:
+                            if visited_map[nr][nc] == 0 and not seen[nr][nc]:
+                                seen[nr][nc] = True
+                                queue.append((nr, nc))
+                if not touches_border:
+                    loops += 1
+    return loops
+
+
 @dataclass
 class CollatzAnt:
     """Stateful Collatz Ant implementation."""
@@ -56,6 +101,8 @@ class CollatzAnt:
     position: Position = (0, 0)
     orientation: int = 0  # orientation index
     orientation_mod: int = field(init=False)
+    steps_taken: int = 0
+    loop_count: int = 0
 
     def __post_init__(self) -> None:
         self.grid[self.position] = self.start_value
@@ -82,7 +129,17 @@ class CollatzAnt:
 
         self.position = move_forward(self.position, self.orientation, self.version)
         self.grid[self.position] = new_value
+        self.steps_taken += 1
+
         return self.position, new_value
+
+    def update_loop_count(self) -> int:
+        """Recalculate ``loop_count`` based on the current grid."""
+        if self.version != "regular":
+            self.loop_count = 0
+            return 0
+        self.loop_count = count_loops(self.grid)
+        return self.loop_count
 
     def history(self, steps: int) -> Iterable[Tuple[Position, int]]:
         """Iterate over ``steps`` simulation steps including the start state."""
@@ -111,12 +168,17 @@ def main():
     )
     args = parser.parse_args()
 
-    for step, (pos, val) in enumerate(simulate(args.start, args.steps, args.version)):
+    ant = CollatzAnt(args.start, version=args.version)
+    for step, (pos, val) in enumerate(ant.history(args.steps)):
         x, y = pos
         color = "black" if val % 2 else "white"
         print(
             f"{step:4d}: position=({x:3d},{y:3d}) value={val:>10} color={color}"
         )
+
+    if args.version == "regular":
+        ant.update_loop_count()
+        print(f"Loops observed: {ant.loop_count}")
 
 
 if __name__ == "__main__":

--- a/visuals.py
+++ b/visuals.py
@@ -38,6 +38,8 @@ class AntVisualizer:
         self.root.grid_columnconfigure(0, weight=1)
         self.speed_label = tk.Label(self.root)
         self.speed_label.grid(row=2, column=0, columnspan=2)
+        self.loop_label = tk.Label(self.root, text="Loops observed: 0")
+        self.loop_label.grid(row=3, column=0, columnspan=2, sticky="e")
 
         extent = INITIAL_EXTENT
         self.canvas.config(scrollregion=(-extent, -extent, extent, extent))
@@ -164,6 +166,9 @@ class AntVisualizer:
         pos, val = self.ant.step()
         self.draw_cell(pos, val)
         self.draw_ant()
+        if self.ant.version == "regular":
+            self.ant.update_loop_count()
+            self.loop_label.config(text=f"Loops observed: {self.ant.loop_count}")
         self.update_scrollregion()
         self.root.after(self.delay, self.step)
 


### PR DESCRIPTION
## Summary
- implement loop counting by analyzing enclosed holes in the grid
- expose `update_loop_count` in `CollatzAnt` for UI updates
- print loops after CLI runs and show them in the Tkinter UI
- document loop detection in README
